### PR TITLE
PFMD-614: Remove require release option

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,9 +30,6 @@ The following snippet demonstrates its use:
           use-ssh: true
 ```
 
-### Adds `require-release` option
-Defaults to `true` to replicate existing functionalty, but when set to `false`, will not cause a CI failure if no tag is present. In some workflows not every commit requires a release.
-
 # pr-semver-bump
 
 [![Build Status](https://img.shields.io/github/actions/workflow/status/jefflinse/pr-semver-bump/master-ci.yml?branch=master)](https://github.com/jefflinse/pr-semver-bump/actions/workflows/master-ci.yml?query=branch%3Amaster)

--- a/action.yml
+++ b/action.yml
@@ -43,10 +43,6 @@ inputs:
     description: Set to 'true' to prefix versions with 'v'
     required: false
     default: 'false'
-  require-release:
-    description: Set to false to disable requiring a release in a merged PR
-    required: false
-    default: true
   base-branch:
     description: Set to 'true' to only consider version tags on the PR base branch. By default considers all version tags in the repository.
     required: false


### PR DESCRIPTION
### SUMMARY
This PR tidies up the changes from the manual `require-release` option we added previously (see [here](https://github.com/Spatial-Quotient/pr-semver-bump/pull/2)), as it's now replaced by the `noop-labels` functionality from the upstream repo. I think it's best to stay aligned with that to ease future upgrades, since they serve the same functionality.

You can read more about it here:
- https://github.com/jefflinse/pr-semver-bump?tab=readme-ov-file#inputs

We'll need to adjust the usages of this repo accordingly.

### RELEASE NOTES

fix: remove required release functionality as now legacy
